### PR TITLE
Update api.js

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -219,4 +219,20 @@ router.post("/setcommand/:detector", checkKey, function(req, res) {
   }).catch((err) => res.json({message: err.message}));
 });
 
+function GetSystemMonitorStatus(collection, host, callback) {
+  var query = {host: host,};
+  var options = {sort: {'_id': -1}, limit: 1};
+  return collection.find(query, options);
+}
+router.get("/getsystemmonitor/:host", checkKey, function(req, res) {
+  var host = req.params.host
+  var collection = req.db.get("system_monitor");
+  GetSystemMonitorStatus(collection,host).then( docs => {
+    if (docs.length == 0)
+      return res.json({message: "No status update found for this host"});
+    return res.json(docs[0]);
+  }).catch( err => {
+    return res.json({message: err.message});
+  });
+});
 module.exports = router;

--- a/routes/api.js
+++ b/routes/api.js
@@ -219,12 +219,12 @@ router.post("/setcommand/:detector", checkKey, function(req, res) {
   }).catch((err) => res.json({message: err.message}));
 });
 
-function GetSystemMonitorStatus(collection, host, callback) {
+function GetSystemMonitorStatus(collection, host) {
   var query = {host: host,};
   var options = {sort: {'_id': -1}, limit: 1};
   return collection.find(query, options);
 }
-router.get("/getsystemmonitor/:host", checkKey, function(req, res) {
+router.get("/gethoststatus/:host", checkKey, function(req, res) {
   var host = req.params.host
   var collection = req.db.get("system_monitor");
   GetSystemMonitorStatus(collection,host).then( docs => {


### PR DESCRIPTION
This pull request adds a API for the system monitor collection

Example use:
```python
hosts = ['eb0','eb1','eb2','eb3','eb4','eb5','ceph','oldmaster','reader0','reader1',
         'reader2','reader3','reader4','reader5','reader6',]
while(1):
    for h in hosts:
        print(requests.get(f'https://xenon1t-daq.lngs.infn.it/test/api/gethoststatus/{h}',
                   {'api_user': os.environ['daq_user'], 'api_key': os.environ['daq_api']}).json())
    time.sleep(5)
```