### PR TITLE
Improved logic for control page

### DIFF
--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -183,7 +183,7 @@ function PullServerData(callback){
       $(`#${detector}_mode option`).filter(val => val === doc.state.mode).prop('selected', true);
       $(`#${detector}_user`).val(doc.user);
 
-      ['active', 'remote', 'softstop'].forEach(att => $(`#${detector}_${att}).bootstrapToggle(doc.state[att] == 'true' ? 'on' : 'off'));
+      ['active', 'remote', 'softstop'].forEach(att => $(`#${detector}_${att}`).bootstrapToggle(doc.state[att] == 'true' ? 'on' : 'off'));
 
       if(detector === "tpc"){
         ['link_mv', 'link_nv'].forEach(att => $("#" + att).bootstrapToggle(doc.state[att] == 'true' ? 'on' : 'off'));
@@ -217,12 +217,13 @@ function PostServerData(){
         thisdet[att] = $("#"+att).is(":checked");
       });
     }
+    console.log(thisdet);
     if (Object.items(thisdet).length == 0)
-      continue;
+      return;
     thisdet['detector'] = detector;
     thisdet['user'] = document.current_user;
     post[detector] = thisdet;
-    empty = false;
+    empty &= false;
   });
 
   if (!empty) {

--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -11,7 +11,7 @@ function DefineButtonRules(){
       var val = 'off';
 
       // First, fail in case "remote" mode enabled"
-      if(!$("#tpc_remote").is(":checked")){
+      if($("#tpc_remote").is(":checked")){
         alert("You cannot control the TPC when it is in remote mode!");
         $("#tpc_active").bootstrapToggle('toggle');
         document.page_ready = true;
@@ -29,7 +29,7 @@ function DefineButtonRules(){
       document.page_ready = false;
 
       // First, fail in case "remote" mode enabled"
-      if(!$("#muon_veto_remote").is(":checked")){
+      if($("#muon_veto_remote").is(":checked")){
         alert("You cannot control the muon veto when it is in remote mode!");
         $("#muon_veto_active").bootstrapToggle('toggle');
         document.page_ready = true;
@@ -38,8 +38,11 @@ function DefineButtonRules(){
 
       var val = 'off';
       if($("#muon_veto_active").is(":checked")) val = 'on';
-      if($("#link_mv").is(":checked")) {$("#tpc_active").bootstrapToggle(val);
-        if($("#link_nv").is(":checked")) $("#neutron_veto_active").bootstrapToggle(val); }
+      if($("#link_mv").is(":checked")) {
+        $("#tpc_active").bootstrapToggle(val);
+        if($("#link_nv").is(":checked"))
+          $("#neutron_veto_active").bootstrapToggle(val); 
+      }
       document.page_ready = true;
     }
   });
@@ -48,7 +51,7 @@ function DefineButtonRules(){
       document.page_ready = false;
 
       // First, fail in case "remote" mode enabled"
-      if(!$("#neutron_veto_remote").is(":checked")){
+      if($("#neutron_veto_remote").is(":checked")){
         alert("You cannot control the neutron veto when it is in remote mode!");
         $("#neutron_veto_active").bootstrapToggle('toggle');
         document.page_ready = true;
@@ -86,7 +89,7 @@ function DefineButtonRules(){
   $("#tpc_remote").change(function(){
     if(document.page_ready){
       document.page_ready = false;
-      if(!$("#tpc_remote").is(":checked")){
+      if($("#tpc_remote").is(":checked")){
         $("#tpc_active").bootstrapToggle('off');
         $("#link_nv").bootstrapToggle('off');
         $("#link_mv").bootstrapToggle('off');
@@ -98,7 +101,7 @@ function DefineButtonRules(){
   $("#muon_veto_remote").change(function(){
     if(document.page_ready){
       document.page_ready = false;
-      if(!$("#muon_veto_remote").is(":checked")){
+      if($("#muon_veto_remote").is(":checked")){
         $("#muon_veto_active").bootstrapToggle('off');
         $("#link_mv").bootstrapToggle('off');
       }
@@ -109,7 +112,7 @@ function DefineButtonRules(){
   $("#neutron_veto_remote").change(function(){
     if(document.page_ready){
       document.page_ready = false;
-      if(!$("#neutron_veto_remote").is(":checked")){
+      if($("#neutron_veto_remote").is(":checked")){
         $("#neutron_veto_active").bootstrapToggle('off');
         $("#link_nv").bootstrapToggle('off');
       }
@@ -138,7 +141,7 @@ function DefineButtonRules(){
 }
 
 function PopulateOptionsLists(callback){
-  $("#remote_lz").bootstrapToggle('off');
+  $("#remote_lz").bootstrapToggle('on');
   $("#lz_softstop").bootstrapToggle('off');
   document.getElementById("lz_mode").innerHTML = "<option value='shit'><strong>xenon leak mode</strong></option><option value='goblind'><strong>HV spark mode</strong></option><option value='oops'><strong>find dark matter but it turns out not to be dark matter mode</strong></option><option value='n'><strong>Only measure neutrons because of all our teflon mode</strong></option><option value='blow'><strong>Lots of radon mode (note, this mode cannot be turned off)</strong></option><option value='whoops'>Don't drift electrons because all the teflon outgasses too much mode</option>";
   $.getJSON("control/modes", (data) => {
@@ -168,11 +171,11 @@ function PopulateOptionsLists(callback){
 
 function PullServerData(callback){
   $.getJSON("control/get_control_docs", function(data){
-    for(var i in data){
-      var doc = data[i];
+    document.page_ready = false;
+    data.forEach(doc => {
       var detector = doc['detector'];
       if(detector !== 'tpc' && detector !== 'muon_veto' && detector !== 'neutron_veto'){
-        continue;
+        return;
       }
       initial_control[detector] = doc.state;
       ["stop_after", "comment"].forEach( (att) => $(`#${detector}_${att}`).val(doc.state[att]));
@@ -183,13 +186,12 @@ function PullServerData(callback){
       ['active', 'remote', 'softstop'].forEach(att => $(`#${detector}_${att}).bootstrapToggle(doc.state[att] == 'true' ? 'on' : 'off'));
 
       if(detector === "tpc"){
-        ['link_mv', 'link_nv'].forEach(att => $("#" + att).bootstrapToggle(doc.state[att] === 'true' ? 'on' : 'off'));
+        ['link_mv', 'link_nv'].forEach(att => $("#" + att).bootstrapToggle(doc.state[att] == 'true' ? 'on' : 'off'));
       }
-    }
+    });
     document.page_ready = true;
     callback;
   });
-
 }
 
 function PostServerData(){
@@ -216,7 +218,7 @@ function PostServerData(){
       });
     }
     if (Object.items(thisdet).length == 0)
-      continue
+      continue;
     thisdet['detector'] = detector;
     thisdet['user'] = document.current_user;
     post[detector] = thisdet;
@@ -230,9 +232,7 @@ function PostServerData(){
       data: {"data": post},
       success: () => location.reload(),
       error: function(jqXHR, textStatus, errorThrown) {
-        alert("Error, status = " + textStatus + ", " +
-          "error thrown: " + errorThrown
-        );
+        alert("Error, status = " + textStatus + ", " + "error thrown: " + errorThrown);
       }
     });
   }

--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -60,8 +60,11 @@ function DefineButtonRules(){
 
       var val = 'off';
       if($("#neutron_veto_active").is(":checked")) val = 'on';
-      if($("#link_nv").is(":checked")) {$("#tpc_active").bootstrapToggle(val);
-        if($("#link_mv").is(":checked")) $("#muon_veto_active").bootstrapToggle(val); }
+      if($("#link_nv").is(":checked")) {
+        $("#tpc_active").bootstrapToggle(val);
+        if($("#link_mv").is(":checked"))
+          $("#muon_veto_active").bootstrapToggle(val);
+      }
       document.page_ready = true;
     }
   });
@@ -140,7 +143,7 @@ function DefineButtonRules(){
 }
 
 function PopulateOptionsLists(callback){
-  $("#ls_remote").bootstrapToggle('on');
+  $("#lz_remote").bootstrapToggle('on');
   $("#lz_softstop").bootstrapToggle('off');
   document.getElementById("lz_mode").innerHTML = "<option value='shit'><strong>xenon leak mode</strong></option><option value='goblind'><strong>HV spark mode</strong></option><option value='oops'><strong>find dark matter but it turns out not to be dark matter mode</strong></option><option value='n'><strong>Only measure neutrons because of all our teflon mode</strong></option><option value='blow'><strong>Lots of radon mode (note, this mode cannot be turned off)</strong></option><option value='whoops'>Don't drift electrons because all the teflon outgasses too much mode</option>";
   $.getJSON("control/modes", (data) => {

--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -1,264 +1,239 @@
+var initial_control = {};
+
 function DefineButtonRules(){
-    
-    $("input").change(function(){if(document.page_ready==true){$("#confirm_div").fadeIn("fast"); $(".my_name_is").val(document.current_user);}});
-    $("select").change(function(){if(document.page_ready==true){$("#confirm_div").fadeIn("fast"); $(".my_name_is").val(document.current_user);}});
-    
-    $("#tpc_active").change(function(){
-	if(document.page_ready){
-	    document.page_ready = false;
-	    var val = 'off';
 
-	    // First, fail in case "remote" mode enabled"
-	    if(!$("#remote_tpc").is(":checked")){
-		alert("You cannot control the TPC when it is in remote mode!");
-		$("#tpc_active").bootstrapToggle('toggle');
-		document.page_ready = true;
-		return;
-	    }
-	    
-	    if($("#tpc_active").is(":checked")) val = 'on';
-	    if($("#link_mv").is(":checked")) $("#muon_veto_active").bootstrapToggle(val);
-	    if($("#link_nv").is(":checked")) $("#neutron_veto_active").bootstrapToggle(val);
-	    document.page_ready = true;
-	}
-    });
-    $("#muon_veto_active").change(function(){
-	if(document.page_ready){
-	    document.page_ready = false;
+  $("input").change(function(){if(document.page_ready==true){$("#confirm_div").fadeIn("fast"); $(".my_name_is").val(document.current_user);}});
+  $("select").change(function(){if(document.page_ready==true){$("#confirm_div").fadeIn("fast"); $(".my_name_is").val(document.current_user);}});
 
-	    // First, fail in case "remote" mode enabled"
-	    if(!$("#remote_muon_veto").is(":checked")){
-		alert("You cannot control the muon veto when it is in remote mode!");
-		$("#muon_veto_active").bootstrapToggle('toggle');
-		document.page_ready = true;
-		return;
-	    }
-	    
-	    var val = 'off';
-	    if($("#muon_veto_active").is(":checked")) val = 'on';
-	    if($("#link_mv").is(":checked")) {$("#tpc_active").bootstrapToggle(val);
-					      if($("#link_nv").is(":checked")) $("#neutron_veto_active").bootstrapToggle(val); }
-	    document.page_ready = true;
-	}
-    });
-    $("#neutron_veto_active").change(function(){
-	if(document.page_ready){
-	    document.page_ready = false;
+  $("#tpc_active").change(function(){
+    if(document.page_ready){
+      document.page_ready = false;
+      var val = 'off';
 
-	    // First, fail in case "remote" mode enabled"
-	    if(!$("#remote_neutron_veto").is(":checked")){
-		alert("You cannot control the neutron veto when it is in remote mode!");
-		$("#neutron_veto_active").bootstrapToggle('toggle');
-		document.page_ready = true;
-		return;
-	    }
-	    
-	    var val = 'off';
-	    if($("#neutron_veto_active").is(":checked")) val = 'on';
-	    if($("#link_nv").is(":checked")) {$("#tpc_active").bootstrapToggle(val);
-					      if($("#link_mv").is(":checked")) $("#muon_veto_active").bootstrapToggle(val); }
-	    document.page_ready = true;
-	}
-    });
-    
-    $("#link_nv").change(function(){
-	if(document.page_ready){
-	    document.page_ready = false;
-	    var val = 'off';
-	    if($("#tpc_active").is(":checked")) val = 'on';
-	    if($("#link_nv").is(":checked")) $("#neutron_veto_active").bootstrapToggle(val);
-	    document.page_ready = true;
-	}
-    });
-    $("#link_mv").change(function(){
-	if(document.page_ready){
-	    document.page_ready = false;
-	    var val = 'off';
-	    if($("#tpc_active").is(":checked")) val = 'on';
-	    if($("#link_mv").is(":checked")) $("#muon_veto_active").bootstrapToggle(val);
-	    document.page_ready = true;
-	}
-    });
+      // First, fail in case "remote" mode enabled"
+      if(!$("#tpc_remote").is(":checked")){
+        alert("You cannot control the TPC when it is in remote mode!");
+        $("#tpc_active").bootstrapToggle('toggle');
+        document.page_ready = true;
+        return;
+      }
 
-    // Remote mode TPC: unlink both other detectors, set TPC to IDLE
-    $("#remote_tpc").change(function(){
-	if(document.page_ready){
-	    document.page_ready = false;
-	    if(!$("#remote_tpc").is(":checked")){
-		$("#tpc_active").bootstrapToggle('off');
-		$("#link_nv").bootstrapToggle('off');
-		$("#link_mv").bootstrapToggle('off');
-	    }
-	    document.page_ready = true;
-	}
-    });
-    // Remote mode MV: unlink MV if linked, set MV to IDLE
-    $("#remote_muon_veto").change(function(){
-	if(document.page_ready){
-	    document.page_ready = false;
-	    if(!$("#remote_muon_veto").is(":checked")){
-		$("#muon_veto_active").bootstrapToggle('off');
-		$("#link_mv").bootstrapToggle('off');
-	    }
-	    document.page_ready = true;
-	}
-    });
-    // Remote mode NV: unlink NV if linked, set NV to IDLE
-    $("#remote_neutron_veto").change(function(){
-	if(document.page_ready){
-	    document.page_ready = false;
-	    if(!$("#remote_neutron_veto").is(":checked")){
-		$("#neutron_veto_active").bootstrapToggle('off');
-		$("#link_nv").bootstrapToggle('off');
-	    }
-	    document.page_ready = true;
-	}
-    });
-    $("#remote_lz").change(function(){
-	if($("#remote_lz").is(":checked")){
-	    alert("You can't stop LZ");
-	    $("#remote_lz").bootstrapToggle('off');
-	}
-    });
-    $("#lz_active").change(function(){
-	if(document.page_ready){
-	    document.page_ready = false;
-	    alert("LZ is in 'remote' mode.");
-	    $("#lz_active").bootstrapToggle("toggle");
-	    document.page_ready = true;
-	}
-	//return;
-    });
-    $("#lz_softstop").change(function(){
-	if($("#lz_softstop").is(":checked")){
-	    alert("You want to go soft on LZ? I hope you aren't an AC");
-	    $("#lz_softstop").bootstrapToggle('off');
-	}
-    });
+      if($("#tpc_active").is(":checked")) val = 'on';
+      if($("#link_mv").is(":checked")) $("#muon_veto_active").bootstrapToggle(val);
+      if($("#link_nv").is(":checked")) $("#neutron_veto_active").bootstrapToggle(val);
+      document.page_ready = true;
+    }
+  });
+  $("#muon_veto_active").change(function(){
+    if(document.page_ready){
+      document.page_ready = false;
+
+      // First, fail in case "remote" mode enabled"
+      if(!$("#muon_veto_remote").is(":checked")){
+        alert("You cannot control the muon veto when it is in remote mode!");
+        $("#muon_veto_active").bootstrapToggle('toggle');
+        document.page_ready = true;
+        return;
+      }
+
+      var val = 'off';
+      if($("#muon_veto_active").is(":checked")) val = 'on';
+      if($("#link_mv").is(":checked")) {$("#tpc_active").bootstrapToggle(val);
+        if($("#link_nv").is(":checked")) $("#neutron_veto_active").bootstrapToggle(val); }
+      document.page_ready = true;
+    }
+  });
+  $("#neutron_veto_active").change(function(){
+    if(document.page_ready){
+      document.page_ready = false;
+
+      // First, fail in case "remote" mode enabled"
+      if(!$("#neutron_veto_remote").is(":checked")){
+        alert("You cannot control the neutron veto when it is in remote mode!");
+        $("#neutron_veto_active").bootstrapToggle('toggle');
+        document.page_ready = true;
+        return;
+      }
+
+      var val = 'off';
+      if($("#neutron_veto_active").is(":checked")) val = 'on';
+      if($("#link_nv").is(":checked")) {$("#tpc_active").bootstrapToggle(val);
+        if($("#link_mv").is(":checked")) $("#muon_veto_active").bootstrapToggle(val); }
+      document.page_ready = true;
+    }
+  });
+
+  $("#link_nv").change(function(){
+    if(document.page_ready){
+      document.page_ready = false;
+      var val = 'off';
+      if($("#tpc_active").is(":checked")) val = 'on';
+      if($("#link_nv").is(":checked")) $("#neutron_veto_active").bootstrapToggle(val);
+      document.page_ready = true;
+    }
+  });
+  $("#link_mv").change(function(){
+    if(document.page_ready){
+      document.page_ready = false;
+      var val = 'off';
+      if($("#tpc_active").is(":checked")) val = 'on';
+      if($("#link_mv").is(":checked")) $("#muon_veto_active").bootstrapToggle(val);
+      document.page_ready = true;
+    }
+  });
+
+  // Remote mode TPC: unlink both other detectors, set TPC to IDLE
+  $("#tpc_remote").change(function(){
+    if(document.page_ready){
+      document.page_ready = false;
+      if(!$("#tpc_remote").is(":checked")){
+        $("#tpc_active").bootstrapToggle('off');
+        $("#link_nv").bootstrapToggle('off');
+        $("#link_mv").bootstrapToggle('off');
+      }
+      document.page_ready = true;
+    }
+  });
+  // Remote mode MV: unlink MV if linked, set MV to IDLE
+  $("#muon_veto_remote").change(function(){
+    if(document.page_ready){
+      document.page_ready = false;
+      if(!$("#muon_veto_remote").is(":checked")){
+        $("#muon_veto_active").bootstrapToggle('off');
+        $("#link_mv").bootstrapToggle('off');
+      }
+      document.page_ready = true;
+    }
+  });
+  // Remote mode NV: unlink NV if linked, set NV to IDLE
+  $("#neutron_veto_remote").change(function(){
+    if(document.page_ready){
+      document.page_ready = false;
+      if(!$("#neutron_veto_remote").is(":checked")){
+        $("#neutron_veto_active").bootstrapToggle('off');
+        $("#link_nv").bootstrapToggle('off');
+      }
+      document.page_ready = true;
+    }
+  });
+  $("#lz_remote").change(function(){
+    if($("#remote_lz").is(":checked")){
+      alert("Local control of LZ is only available from SURF");
+      $("#remote_lz").bootstrapToggle('on');
+    }
+  });
+  $("#lz_active").change(function(){
+    if(document.page_ready){
+      alert("You can't stop LZ");
+      $("#lz_active").bootstrapToggle("on");
+    }
+    //return;
+  });
+  $("#lz_softstop").change(function(){
+    if($("#lz_softstop").is(":checked")){
+      alert("You want to go soft on LZ? I hope you aren't an AC");
+      $("#lz_softstop").bootstrapToggle('off');
+    }
+  });
 }
 
-function PopulateRunsList(callback){
-    var detectors = ['tpc', 'muon_veto', 'neutron_veto'];
-    var fetched = 0;
-    for(var i in detectors){
-    	var detector = detectors[i];
-    	$.getJSON("control/modes?detector="+detector, (function(d){ return function(data){
-    		var html = "";
-    		for(var j=0; j<data.length; j+=1)
-	    		html+="<option value='"+data[j][0]+"'><strong>"+data[j][0]+":</strong> "+data[j][1]+"</option>";
-			var sdiv = d + "_mode";
-			document.getElementById(sdiv).innerHTML = html;
-			fetched+=1;
-			if(fetched === 3){
-				callback();
-			}
+function PopulateOptionsLists(callback){
+  $("#remote_lz").bootstrapToggle('off');
+  $("#lz_softstop").bootstrapToggle('off');
+  document.getElementById("lz_mode").innerHTML = "<option value='shit'><strong>xenon leak mode</strong></option><option value='goblind'><strong>HV spark mode</strong></option><option value='oops'><strong>find dark matter but it turns out not to be dark matter mode</strong></option><option value='n'><strong>Only measure neutrons because of all our teflon mode</strong></option><option value='blow'><strong>Lots of radon mode (note, this mode cannot be turned off)</strong></option><option value='whoops'>Don't drift electrons because all the teflon outgasses too much mode</option>";
+  $.getJSON("control/modes", (data) => {
+    if (typeof data.message != 'undefined') {
+      console.log(data);
+      return;
+    }
+    // [{_id: detector name, configs: []}, {_id: detector name....}]
+    data.forEach(doc => $("#"+doc['_id']+"_mode").html(doc['configs'].reduce((html, val) => "<option value='"+val[0]+"'><strong>"+val[0]+":</strong> "+val[1]+"</option>", "")));
+    callback();
+  }
+  /*for(var i in detectors){
+    var detector = detectors[i];
+    $.getJSON("control/modes?detector="+detector, (function(d){ return function(data){
+      var html = "";
+      for(var j=0; j<data.length; j+=1)
+        html+="<option value='"+data[j][0]+"'><strong>"+data[j][0]+":</strong> "+data[j][1]+"</option>";
+      var sdiv = d + "_mode";
+      document.getElementById(sdiv).innerHTML = html;
+      fetched+=1;
+      if(fetched === 3){
+        callback();
+      }
 
-    	}}(detector)));
-	$("#remote_lz").bootstrapToggle('off');
-	$("#lz_softstop").bootstrapToggle('off');
-	document.getElementById("lz_mode").innerHTML = "<option value='shit'><strong>xenon leak mode</strong></option><option value='goblind'><strong>HV spark mode</strong></option><option value='oops'><strong>find dark matter but it turns out not to be dark matter mode</strong></option><option value='n'><strong>Only measure neutrons because of all our teflon mode</strong></option><option value='blow'><strong>Lots of radon mode (note, this mode cannot be turned off)</strong></option>";
-	
-	}
+    }}(detector)));*/
 }
 
 function PullServerData(callback){
-	$.getJSON("control/get_control_docs", function(data){
-		var found = 0;
-		for(var i in data){
-			var doc = data[i];
-			var detector = doc['detector'];
-			if(detector !== 'tpc' && detector !== 'muon_veto' && detector !== 'neutron_veto'){
-				continue;
-			}
-			found += 1;
-		    var atts = ["stop_after", "mode", "comment"];
-		    for(var j in atts){
-			var att = atts[j];
-			var divname = "#" + detector + "_" + att;
-			if(att === 'mode'){
-			    $(divname + " option").filter(function() {
-    					return this.value === doc.state['mode']
-  					}).prop('selected', true);
-			}
-			else
-			    $(divname).val(doc.state[att]);
-			}
-            $("#"+detector+"_user").val(doc.user);
-            if (doc.state['finish_run_on_stop'] == 'true')
-                $("#" + detector + "_softstop").prop('selected', true);
-            else
-                $("#" + detector + "_softstop").prop('selected', false);
+  $.getJSON("control/get_control_docs", function(data){
+    for(var i in data){
+      var doc = data[i];
+      var detector = doc['detector'];
+      if(detector !== 'tpc' && detector !== 'muon_veto' && detector !== 'neutron_veto'){
+        continue;
+      }
+      initial_control[detector] = doc.state;
+      ["stop_after", "comment"].forEach( (att) => $(`#${detector}_${att}`).val(doc.state[att]));
 
-		    if(detector === "tpc"){
-			if(doc.state['link_mv'] === 'true')
-			    $("#link_mv").bootstrapToggle('on');
-			else
-			    $("#link_mv").bootstrapToggle('off');
-			if(doc.state['link_nv'] === 'true')
-			    $("#link_nv").bootstrapToggle('on');
-			else
-			    $("#link_nv").bootstrapToggle('off');
-		    }
+      $(`#${detector}_mode option`).filter(val => val === doc.state.mode).prop('selected', true);
+      $(`#${detector}_user`).val(doc.user);
 
-		    if(doc.state['remote'] == 'true')
-			$("#remote_" + detector).bootstrapToggle('off');
-		    else
-			$("#remote_" + detector).bootstrapToggle('on');
-		    if(doc.state['active'] === "true")
-			$("#"+detector+"_active").bootstrapToggle('on');
-		    else
-			$("#"+detector+"_active").bootstrapToggle('off');
-		}
-		if(found !== 3)
-			alert("Didn't find data for all detectors! Must be you have a clean slate.")
-		document.page_ready = true;
-		callback;
-	});
+      ['active', 'remote', 'softstop'].forEach(att => $(`#${detector}_${att}).bootstrapToggle(doc.state[att] == 'true' ? 'on' : 'off'));
+
+      if(detector === "tpc"){
+        ['link_mv', 'link_nv'].forEach(att => $("#" + att).bootstrapToggle(doc.state[att] === 'true' ? 'on' : 'off'));
+      }
+    }
+    document.page_ready = true;
+    callback;
+  });
 
 }
 
 function PostServerData(){
-    var dets = ['tpc', 'muon_veto', 'neutron_veto'];
-    post = {};
-    var failed = false;
-    for(var i in dets){
-	    var detector = dets[i];
-	    var thisdet = {"detector": detector};
-	    thisdet['active'] = $("#"+detector+"_active").is(":checked");
+  post = {};
+  var empty = true;
+  ['tpc', 'muon_veto', 'neutron_veto'].forEach(detector => {
+    var thisdet = {};
+    ['active', 'remote', 'softstop'].forEach( (att) => {
+      var checked = $(`#${detector}_${att}`).is(":checked");
+      if (checked != initial_control[detector][att])
+        thisdet[att] = checked;
+    });
 
-	var atts = ["stop_after", "mode", "user", "comment"];
-	    for(var j in atts){
-		var att = atts[j];
-		var divname = "#" + detector + "_" + att;
-		thisdet[att] = $(divname).val();
-		if(thisdet['active'] && thisdet[att] === null || typeof thisdet[att] === "undefined" && (att!=="comment" && att!=="stop_after")){
-		    alert("You need to provide a value for "+att+" for the "+detector+", or disable that detector.");
-		    failed = true;
-		}
-	    }
-	thisdet['active'] = $("#"+detector+"_active").is(":checked");
-	thisdet['remote'] = (!$("#remote_" + detector).is(":checked"));
-	if(detector === "tpc"){
-	    thisdet['link_mv'] = $("#link_mv").is(":checked");
-	    thisdet['link_nv'] = $("#link_nv").is(":checked");
-	}
-        thisdet["finish_run_on_stop"] = $("#"+detector+"_softstop").is(":checked");
-	post[detector] = thisdet;
+    ["stop_after", "mode", "comment"].forEach( (att) => {
+      var val = $(`#${detector}_${att}`).val();
+      if (val != initial_control[detector][att])
+        thisdet[att] = val;
+    });
+
+    if(detector === "tpc"){
+      ['link_mv','link_nv'].forEach( (att) => {
+      if ($("#" + att).is(":checked") != initial_control['tpc'][att])
+        thisdet[att] = $("#"+att).is(":checked");
+      });
     }
+    if (Object.items(thisdet).length == 0)
+      continue
+    thisdet['detector'] = detector;
+    thisdet['user'] = document.current_user;
+    post[detector] = thisdet;
+    empty = false;
+  });
 
-    if(!failed){
-		$.ajax({
-		    type: "POST",
-	   		url: "control/set_control_docs",
-	  		data: {"data": post},
-	    	success: function(){
-		   		location.reload();
-		   	},
-		   	error:   function(jqXHR, textStatus, errorThrown) {
-			alert("Error, status = " + textStatus + ", " +
-			   	  "error thrown: " + errorThrown
-			 	);
-		    }
-		});
-	}
+  if (!empty) {
+    $.ajax({
+      type: "POST",
+      url: "control/set_control_docs",
+      data: {"data": post},
+      success: () => location.reload(),
+      error: function(jqXHR, textStatus, errorThrown) {
+        alert("Error, status = " + textStatus + ", " +
+          "error thrown: " + errorThrown
+        );
+      }
+    });
+  }
 }

--- a/public/javascripts/control.js
+++ b/public/javascripts/control.js
@@ -120,17 +120,16 @@ function DefineButtonRules(){
     }
   });
   $("#lz_remote").change(function(){
-    if($("#remote_lz").is(":checked")){
+    if(!$("#remote_lz").is(":checked")){
       alert("Local control of LZ is only available from SURF");
       $("#remote_lz").bootstrapToggle('on');
     }
   });
   $("#lz_active").change(function(){
-    if(document.page_ready){
+    if (!$("#lz_active").is(":checked")) {
       alert("You can't stop LZ");
       $("#lz_active").bootstrapToggle("on");
     }
-    //return;
   });
   $("#lz_softstop").change(function(){
     if($("#lz_softstop").is(":checked")){
@@ -152,7 +151,7 @@ function PopulateOptionsLists(callback){
     // [{_id: detector name, configs: []}, {_id: detector name....}]
     data.forEach(doc => $("#"+doc['_id']+"_mode").html(doc['configs'].reduce((html, val) => "<option value='"+val[0]+"'><strong>"+val[0]+":</strong> "+val[1]+"</option>", "")));
     callback();
-  }
+  });
   /*for(var i in detectors){
     var detector = detectors[i];
     $.getJSON("control/modes?detector="+detector, (function(d){ return function(data){
@@ -197,6 +196,7 @@ function PullServerData(callback){
 function PostServerData(){
   post = {};
   var empty = true;
+  console.log('Posting?');
   ['tpc', 'muon_veto', 'neutron_veto'].forEach(detector => {
     var thisdet = {};
     ['active', 'remote', 'softstop'].forEach( (att) => {
@@ -218,7 +218,7 @@ function PostServerData(){
       });
     }
     console.log(thisdet);
-    if (Object.items(thisdet).length == 0)
+    if (Object.keys(thisdet).length == 0)
       return;
     thisdet['detector'] = detector;
     thisdet['user'] = document.current_user;

--- a/routes/control.js
+++ b/routes/control.js
@@ -57,7 +57,7 @@ router.get("/get_control_docs", ensureAuthenticated, function(req, res){
     var collection = db.get("detector_control");
     GetControlDocs(collection)
     .then((docs) => res.json(docs))
-    .catch((err) => {console.log(err.message); return res.json({});});
+    .catch((err) => {console.log("GET CONTROL ERROR"); console.log(err.message); return res.json({});});
 });
 
 router.post('/set_control_docs', ensureAuthenticated, function(req, res){
@@ -67,16 +67,13 @@ router.post('/set_control_docs', ensureAuthenticated, function(req, res){
     if (typeof req.user.lngs_ldap_uid == 'undefined')
       return res.sendStatus(401);
     var data = req.body.data;
-  console.log('CONTROL GET DATA');
-  console.log(data);
-  return res.sendStatus(200);
     GetControlDocs(collection).then((docs) => {
       var updates = [];
       for (var i in docs) {
         var olddoc = docs[i];
         var newdoc = data[olddoc['detector']];
         for (var key in olddoc.state)
-          if (newdoc[key] != olddoc.state[key])
+          if (typeof newdoc[key] != 'undefined' && newdoc[key] != olddoc.state[key])
             updates.push({detector: olddoc['detector'], field: key, value: newdoc[key], user: req.user.lngs_ldap_uid, time: new Date(), key: olddoc['detector']+'.'+key});
       }
       if (updates.length > 0)

--- a/routes/control.js
+++ b/routes/control.js
@@ -78,9 +78,10 @@ router.post('/set_control_docs', ensureAuthenticated, function(req, res){
       }
       if (updates.length > 0)
         return collection.insert(updates);
-      return 0;
-    }).then( () => { return res.sendStatus(200);
-    }).catch((err) => {
+      else
+        return 0;
+    }).then( () => res.sendStatus(200))
+    .catch((err) => {
       console.log(err.message);
       return res.sendStatus(451);
     });

--- a/routes/control.js
+++ b/routes/control.js
@@ -22,7 +22,7 @@ router.get('/modes', ensureAuthenticated, function(req, res){
     {$group: {_id: '$detector', options: {$push: '$name'}, desc: {$push: '$description'}}},
     {$project: {configs: {$zip: {inputs: ['$options', '$desc']}}}}
   ]).then( (docs) => res.json(docs))
-  .catch( (err) => {console.log('GET MODES ERROR'); console.log(err.message); return res.json({error: err.message}));
+  .catch( (err) => {console.log('GET MODES ERROR'); console.log(err.message); return res.json({error: err.message})});
 });
 
 function GetControlDocs(collection) {

--- a/views/control.pug
+++ b/views/control.pug
@@ -26,7 +26,7 @@ block content
                 div.form-check-inline
                   label.form-check-label
                     span Control &nbsp;
-                    input(id=`${det[0]}_remote` type="checkbox" checked data-toggle="toggle" data-onstyle="warning" data-offstyle="success" data-on="remote" data-off="web" data-size="small")
+                    input(id=`${det[0]}_remote` type="checkbox" checked data-toggle="toggle" data-onstyle="success" data-offstyle="success" data-on="remote" data-off="local" data-size="small")
                 div.form-check-inline 
                   label.form-check-label
                     span Run &nbsp;

--- a/views/control.pug
+++ b/views/control.pug
@@ -21,21 +21,21 @@ block content
       div.det_card_noheight(style="width:100%;border:1px solid #ccc;margin-top:10px")
         div.row
           div.col-12
-            if det[0] == 'tpc'
-              span(style='font-size:20px;font-weight:bold;') #{det[1]}
-              div.float-right(style='display:inline-block')
-                  div.form-check-inline
-                    label.form-check-label
-                      span Control &nbsp;
-                      input#remote_tpc(type="checkbox" checked data-toggle="toggle" data-onstyle="success" data-offstyle="warning" data-on="web" data-off="remote" data-size="small")
-                  div.form-check-inline 
-                    label.form-check-label
-                      span Run &nbsp;
-                      input#tpc_active(type="checkbox" checked data-toggle="toggle" data-onstyle="success" data-offstyle="danger" data-on="on" data-off="off" data-size='small')
-                  div.form-check-inline 
-                    label.form-check-label
-                      span Soft stop &nbsp;
-                      input#tpc_softstop(type="checkbox" data-toggle="toggle" data-onstyle="success" data-offstyle="danger" data-on="on" data-off="off" data-size='small')
+            span(style='font-size:20px;font-weight:bold;') #{det[1]}
+            div.float-right(style='display:inline-block')
+                div.form-check-inline
+                  label.form-check-label
+                    span Control &nbsp;
+                    input(id=`${det[0]}_remote` type="checkbox" checked data-toggle="toggle" data-onstyle="warning" data-offstyle="success" data-on="remote" data-off="web" data-size="small")
+                div.form-check-inline 
+                  label.form-check-label
+                    span Run &nbsp;
+                    input(id=`${det[0]}_active` type="checkbox" checked data-toggle="toggle" data-onstyle="success" data-offstyle="danger" data-on="on" data-off="off" data-size='small')
+                div.form-check-inline 
+                  label.form-check-label
+                    span Soft stop &nbsp;
+                    input(id=`${det[0]}_softstop` type="checkbox" data-toggle="toggle" data-onstyle="success" data-offstyle="danger" data-on="on" data-off="off" data-size='small')
+                if det[0] == 'tpc'
                   div.form-check-inline 
                     label.form-check-label
                       span Muon Veto &nbsp;
@@ -44,21 +44,6 @@ block content
                     label.form-check-label
                       span Neutron Veto &nbsp;
                       input#link_nv(type="checkbox" checked data-toggle="toggle" data-onstyle="success" data-offstyle="danger"  data-on="Linked" data-off="Unlinked" data-size='small')
-            else
-              span(style='font-size:20px;font-weight:bold;') #{det[1]}
-              div.float-right(style='display:inline-block')
-                div.form-check-inline
-                  label.form-check-label
-                    span Control &nbsp;
-                    input(id=`remote_${det[0]}` type="checkbox" checked data-toggle="toggle" data-onstyle="success" data-offstyle="warning" data-on="web" data-off="remote" data-size="small")
-                div.form-check-inline
-                  label.form-check-label
-                    span Run &nbsp;
-                    input(id=`${det[0]}_active` type="checkbox" checked data-toggle="toggle" data-onstyle="success" data-offstyle="danger" data-on="on" data-off="off" data-size='small')
-                div.form-check-inline
-                  label.form-check-label
-                    span Soft stop &nbsp;
-                    input(id=`${det[0]}_softstop` type="checkbox" data-toggle="toggle" data-onstyle="success" data-offstyle="danger" data-on="on" data-off="off" data-size='small')
         hr(style='margin-top:3px')
         div.row(style="padding:5px")
           div.col-xs-12.col-sm-6.col-md-4.col-xl-2.form-group
@@ -82,6 +67,6 @@ block content
       document.page_ready = false;
       document.current_user = "#{user.lngs_ldap_uid}";
       DrawActiveLink("#lcontrol");
-      PopulateRunsList(PullServerData);
+      PopulateOptionsLists(PullServerData);
       DefineButtonRules();
     });


### PR DESCRIPTION
Control overlaps become common as more people try to use the control interface and they don't refresh the page, which allows stale inputs to be sent to the DAQ control system. This PR changes how the client-side logic is done, where the page will only submit changes the user has made rather than a snapshot of all values.

Also the client-side scripts were re-indented, which is why the change count is so high.