### PR TITLE
New checks for abandoning runs

### DIFF
--- a/public/javascripts/runs_table.js
+++ b/public/javascripts/runs_table.js
@@ -173,9 +173,16 @@ function InitializeRunsTable(divname){
     if(typeof tag ==="undefined")
       console.log("No tag!")
     else{
-      runs = [];
-      for(var i=0; i<table.rows('.selected')[0].length; i++)
-        runs.push(table.rows('.selected').data()[i]['number']);
+      var runs = [];
+      var timelimit = 7*24*3600*1000; // one week
+      for(var i=0; i<table.rows('.selected')[0].length; i++) {
+        var data = table.rows(".selected").data()[i];
+        if (tag === 'abandon' && new Date() - new Date(data.start) > timelimit && data.bootstrax.state !== 'failed') {
+        } else {
+          runs.push(data.number);
+        }
+      }
+      console.log(runs);
       if(runs.length>0)
         $.ajax({
           type: "POST",
@@ -198,6 +205,13 @@ function InitializeRunsTable(divname){
     else{
       var runs = [];
       runs.push($("#detail_Number").html());
+      if (tag === 'abandon') {
+        if (new Date() - new Date($("#detail_Start")) > 7 * 24 * 3600 * 1000 && $("#detail_bootstrax") !== "failed") {
+          // can't abandon unfailed runs older than a week
+          alert("You can't abandon this run");
+          return;
+        }
+      }
       if(runs.length>0 && typeof runs[0] !== "undefined")
         $.ajax({
           type: "POST",
@@ -263,6 +277,7 @@ function ShowDetail(run){
     $("#detail_User").html(data['user']);
     $("#detail_Mode").html(data['mode']);
     $("#detail_Source").html(data['source']);
+    $("#detail_bootstrax").html(data['bootstrax']['state']);
 
     // Tags, if any
     $("#detail_Tags").html(typeof data.tags == 'undefined' ? "" : data['tags'].reduce((total, tag) => {

--- a/public/javascripts/runs_table.js
+++ b/public/javascripts/runs_table.js
@@ -178,6 +178,7 @@ function InitializeRunsTable(divname){
       for(var i=0; i<table.rows('.selected')[0].length; i++) {
         var data = table.rows(".selected").data()[i];
         if (tag === 'abandon' && new Date() - new Date(data.start) > timelimit && data.bootstrax.state !== 'failed') {
+          // can't abandon unfailed runs older than a week
         } else {
           runs.push(data.number);
         }
@@ -205,8 +206,9 @@ function InitializeRunsTable(divname){
     else{
       var runs = [];
       runs.push($("#detail_Number").html());
+      var timelimit = 7*24*3600*1000; // one week
       if (tag === 'abandon') {
-        if (new Date() - new Date($("#detail_Start")) > 7 * 24 * 3600 * 1000 && $("#detail_bootstrax") !== "failed") {
+        if (new Date() - new Date($("#detail_Start")) > timelimit && $("#detail_bootstrax") !== "failed") {
           // can't abandon unfailed runs older than a week
           alert("You can't abandon this run");
           return;

--- a/routes/runsui.js
+++ b/routes/runsui.js
@@ -57,6 +57,9 @@ router.post('/removetag', ensureAuthenticated, function(req, res){
   var tag = req.body.tag;
   var tag_user = req.body.user;
 
+  if (tag[0] === '_') // underscore tags are protected
+    return res.sendStatus(403);
+
   // Convert runs to int
   runint = parseInt(run);
   // Update one

--- a/views/runsui.pug
+++ b/views/runsui.pug
@@ -78,7 +78,11 @@ block content
                       strong #{att}:
                     div.col-sm-6
                       span(id=`detail_${att}`)
-              div.tab-pane.fade#tab_tags(role="tabpanel" aria-labelledby="tags-tab") 
+                  div.col-sm-6
+                    strong Processing status:
+                  div.col-sm-6
+                    span#detail_bootstrax
+              div.tab-pane.fade#tab_tags(role="tabpanel" aria-labelledby="tags-tab")
                 table.table.table-striped
                   thead
                     td Tag


### PR DESCRIPTION
For instance, the website will not allow you to abandon a run that is both older than one week, and not failing to process.

Also, prevents the removal of underscore tags, which was missed in #10.