### PR TITLE
Double rates monitor / overview

### DIFF
--- a/public/javascripts/monitor_scripts.js
+++ b/public/javascripts/monitor_scripts.js
@@ -490,8 +490,8 @@ function PMT_setcolour(json_result, timestamp){
     }
     var t_sorting_duration = Date.now() - t_sorting_start
     
-    
-    
+    //    reset the total rate
+    pmt_rate_sum = 0;
     var t_coloring_start = Date.now()
     color_pmts()
     var t_coloring_duration = Date.now() - t_coloring_start


### PR DESCRIPTION
## What is the issue
The total rate on the monitor page seems double the rate on the overview page .
![afbeelding](https://user-images.githubusercontent.com/22295914/117698820-67e99600-b1c4-11eb-8d0b-98f90b85ddb6.png)

## How is this caused?

- We call `update_color_scheme` [here](https://github.com/XENONnT/nodiaq/blob/ce3be66557c0bb8f05c1239c9110a51a60544abd/public/javascripts/monitor_scripts.js#L488) 
  - that calls `color_pmts` [here](https://github.com/XENONnT/nodiaq/blob/ce3be66557c0bb8f05c1239c9110a51a60544abd/public/javascripts/monitor_scripts.js#L163).
 - next we call `color_pmts` shortly after that on [this line](https://github.com/XENONnT/nodiaq/blob/ce3be66557c0bb8f05c1239c9110a51a60544abd/public/javascripts/monitor_scripts.js#L496)
- So `color_pmts` is called twice, without a reset of `pmt_rate_sum` to 0, which is therefore twice as high, see [here](https://github.com/XENONnT/nodiaq/blob/ce3be66557c0bb8f05c1239c9110a51a60544abd/public/javascripts/monitor_scripts.js#L543)

To test if this is True, just turn of the auto-scaling, the total rate halves.

## Alternative solutions

1. Set `pmt_rate_sum = 0` at each function call of [`color_pmts`](https://github.com/XENONnT/nodiaq/blob/a06cdfb9ca23530441cc99996c1b7b9e67b6e255/public/javascripts/monitor_scripts.js#L525)
2. Don't call the `color_pmts` again after the `if` [statement here (make it an `else`-block)](https://github.com/XENONnT/nodiaq/blob/a06cdfb9ca23530441cc99996c1b7b9e67b6e255/public/javascripts/monitor_scripts.js#L491-L497)
3. Don't call `color_pmts` from within `update_color_scheme`

I also like 1. whereas I am not deep enough into this script to argue for 2. or 3.